### PR TITLE
Improve cookie warning style

### DIFF
--- a/src/main/kotlin/org/olafneumann/grouprandom/browser/CookieBanner.kt
+++ b/src/main/kotlin/org/olafneumann/grouprandom/browser/CookieBanner.kt
@@ -28,6 +28,6 @@ internal object CookieBanner {
     }
 
     private fun hideBanner() {
-        jQuery(ctnCookie).hide()
+        jQuery(ctnCookie).remove()
     }
 }

--- a/src/main/resources/group-randomizer.css
+++ b/src/main/resources/group-randomizer.css
@@ -1,6 +1,9 @@
+#ck_container_cookie {
+	background-color: #000000aa;
+}
 
-a.gr-action-link {
-    /*color: green;*/
+#ck_container_cookie + div {
+	filter: blur(5px);
 }
 
 .gr-action-link-container a.gr-action-link {

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -19,17 +19,19 @@
 </head>
 
 <body class="bg-dark">
-    <div class="container-fluid py-3">
-        <div id="ck_container_cookie" class="alert alert-danger fixed-top m-2" role="alert">
-            <div class="d-flex justify-content-between">
-                <p class="m-0">This site uses cookies to improve your user experience.</p>
-                <div class="btn-group btn-group-sm" role="group">
-                    <button id="ck_btn_reject" type="button" class="btn btn-danger">Reject</button>
-                    <button id="ck_btn_accept" type="button" class="btn btn-success">Accept</button>
-                </div>
-            </div>
-        </div>
+	<div id="ck_container_cookie" class="fixed-top fixed-bottom">
+		<div class="alert alert-danger fixed-top m-2" role="alert">
+			<div class="d-flex justify-content-between">
+				<p class="m-0">This site uses cookies to improve your user experience.</p>
+				<div class="btn-group btn-group-sm" role="group">
+					<button id="ck_btn_reject" type="button" class="btn btn-danger">Reject</button>
+					<button id="ck_btn_accept" type="button" class="btn btn-success">Accept</button>
+				</div>
+			</div>
+		</div>
+	</div>
 
+    <div class="container-fluid py-3">
         <div class="jumbotron bg-info">
             <h1 class="display-4"><span id="rg-title">Group Randomizer</span></h1>
         </div>


### PR DESCRIPTION
This pull request improves the cookie warning design in order to guide users a little better through the cookie warning by making it a modal window.

See the below screenshots for a difference (old first, new second):

![old](https://user-images.githubusercontent.com/880198/89344506-47753400-d6a6-11ea-98f5-097eec067329.png)

![new](https://user-images.githubusercontent.com/880198/89344511-48a66100-d6a6-11ea-828e-b2f5b74f207a.png)
