### PR TITLE
Fix deleting the last existing group

### DIFF
--- a/src/main/kotlin/org/olafneumann/grouprandom/UiController.kt
+++ b/src/main/kotlin/org/olafneumann/grouprandom/UiController.kt
@@ -53,9 +53,11 @@ internal class UiController : DisplayContract.Controller {
     override fun removeGroup(group: Group) {
         ApplicationSettings.deleteGroup(group.name)
         if (group == selectedGroup) {
-            selectGroup(group)
+            selectGroup(null)
+            view.focusNewGroupEditor()
+        } else {
+            refreshUi(refreshTextAdditions = false, regenerateText = false)
         }
-        refreshUi(refreshTextAdditions = false, regenerateText = false)
     }
 
     override fun addGroupMember(name: String) {

--- a/src/main/kotlin/org/olafneumann/grouprandom/UiController.kt
+++ b/src/main/kotlin/org/olafneumann/grouprandom/UiController.kt
@@ -53,7 +53,7 @@ internal class UiController : DisplayContract.Controller {
     override fun removeGroup(group: Group) {
         ApplicationSettings.deleteGroup(group.name)
         if (group == selectedGroup) {
-            selectGroup(null)
+            selectGroup(ApplicationSettings.getGroups().firstOrNull())
             view.focusNewGroupEditor()
         } else {
             refreshUi(refreshTextAdditions = false, regenerateText = false)


### PR DESCRIPTION
Until now deleting the last group existing seems to be possible via the UI, but nothing happens. This fixes deleting the last group from the application settings.