### PR TITLE
Fix the design in case of an empty members list

### DIFF
--- a/src/main/kotlin/org/olafneumann/grouprandom/browser/CookieBanner.kt
+++ b/src/main/kotlin/org/olafneumann/grouprandom/browser/CookieBanner.kt
@@ -28,6 +28,6 @@ internal object CookieBanner {
     }
 
     private fun hideBanner() {
-        jQuery(ctnCookie).remove()
+        ctnCookie.parentNode?.removeChild(ctnCookie)
     }
 }

--- a/src/main/kotlin/org/olafneumann/grouprandom/js/JQuery.kt
+++ b/src/main/kotlin/org/olafneumann/grouprandom/js/JQuery.kt
@@ -1,18 +1,13 @@
 package org.olafneumann.regex.generator.js
 
-import org.w3c.dom.HTMLElement
+import org.w3c.dom.Node
 
 @JsName("$")
-external fun jQuery(id: String): JQuery
-
-fun jQuery(element: HTMLElement) = jQuery("#${element.id}")
+external fun jQuery(id: Node): JQuery
 
 external class JQuery() {
-    fun on(type: String, callback: () -> Unit)
     fun show(): JQuery
     fun hide(): JQuery
-    fun parent(): JQuery
-    fun remove(): JQuery
     fun removeClass(className: String = definedExternally)
     fun addClass(className: String = definedExternally)
 }

--- a/src/main/kotlin/org/olafneumann/grouprandom/js/JQuery.kt
+++ b/src/main/kotlin/org/olafneumann/grouprandom/js/JQuery.kt
@@ -8,6 +8,4 @@ external fun jQuery(id: Node): JQuery
 external class JQuery() {
     fun show(): JQuery
     fun hide(): JQuery
-    fun removeClass(className: String = definedExternally)
-    fun addClass(className: String = definedExternally)
 }

--- a/src/main/kotlin/org/olafneumann/grouprandom/ui/HtmlView.kt
+++ b/src/main/kotlin/org/olafneumann/grouprandom/ui/HtmlView.kt
@@ -130,13 +130,8 @@ class HtmlView(
 
     override fun showGroups(groups: List<Group>) = groupListMaintainer.showItems(groups)
     override fun showMembers(members: List<Member>) {
-        val container = jQuery(divListGroupMembers.parentNode!!)
-        if (members.isEmpty()) {
-            container.addClass(CLASS_HIDE_GROUP_MEMBERS)
-        } else {
-            container.removeClass(CLASS_HIDE_GROUP_MEMBERS)
-            memberListMaintainer.showItems(members)
-        }
+        divListGroupMembers.parentElement?.classList?.toggle(CLASS_HIDE_GROUP_MEMBERS, members.isEmpty())
+        memberListMaintainer.showItems(members)
     }
     override fun showPrefixes(prefixes: List<String>) = prefixListMaintainer.showItems(prefixes)
     override fun showSeparators(separators: List<String>) = separatorListMaintainer.showItems(separators)

--- a/src/main/kotlin/org/olafneumann/grouprandom/ui/HtmlView.kt
+++ b/src/main/kotlin/org/olafneumann/grouprandom/ui/HtmlView.kt
@@ -11,6 +11,7 @@ import org.olafneumann.grouprandom.browser.HtmlHelper
 import org.olafneumann.grouprandom.js.decodeURIComponent
 import org.olafneumann.grouprandom.js.encodeURIComponent
 import org.olafneumann.grouprandom.js.navigator
+import org.olafneumann.regex.generator.js.jQuery
 import org.w3c.dom.*
 import org.w3c.dom.events.Event
 import org.w3c.dom.url.URL
@@ -128,7 +129,15 @@ class HtmlView(
     })
 
     override fun showGroups(groups: List<Group>) = groupListMaintainer.showItems(groups)
-    override fun showMembers(members: List<Member>) = memberListMaintainer.showItems(members)
+    override fun showMembers(members: List<Member>) {
+        val container = jQuery(divListGroupMembers.parentNode!!)
+        if (members.isEmpty()) {
+            container.addClass(CLASS_HIDE_GROUP_MEMBERS)
+        } else {
+            container.removeClass(CLASS_HIDE_GROUP_MEMBERS)
+            memberListMaintainer.showItems(members)
+        }
+    }
     override fun showPrefixes(prefixes: List<String>) = prefixListMaintainer.showItems(prefixes)
     override fun showSeparators(separators: List<String>) = separatorListMaintainer.showItems(separators)
     override fun showPostfixes(postfixes: List<String>) = postfixListMaintainer.showItems(postfixes)
@@ -229,6 +238,7 @@ class HtmlView(
 
     companion object {
         const val CLASS_COPY_BUTTON = "gr-copy-button"
+        const val CLASS_HIDE_GROUP_MEMBERS = "gr-existing-members-hide"
 
         const val EVENT_CLICK = "click"
         private const val EVENT_SUBMIT = "submit"

--- a/src/main/resources/group-randomizer.css
+++ b/src/main/resources/group-randomizer.css
@@ -19,3 +19,12 @@ a.gr-action-link:hover {
 .gr-full-width {
     width: 100%;
 }
+
+.gr-existing-members-hide {
+	display: none;
+}
+
+.gr-existing-members-hide + form {
+	border-top-left-radius: inherit;
+	border-top-right-radius: inherit;
+}


### PR DESCRIPTION
This fix the design in case of an empty members list as shown in the below screenshots (old on top, new below):

![old](https://user-images.githubusercontent.com/880198/89354350-e86cea80-d6b8-11ea-83cb-2bfa054139c2.png)

![new](https://user-images.githubusercontent.com/880198/89354352-e99e1780-d6b8-11ea-8ed3-bd563218018a.png)